### PR TITLE
Add OSX uuid test, fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 coverage
 .nyc_output
 .vscode
+*~
+.idea/
+*.iml

--- a/src/rules/iso_date.js
+++ b/src/rules/iso_date.js
@@ -54,12 +54,12 @@ function getDateFromParams(param, key) {
         date = new Date();
         date.setDate(date.getDate() + (i - 1));
     } else if (!matched || !isDateValid(matched[1])) {
-        throw new Error('LIVR: wrong date in "' + key + '" parametr');
+        throw new Error('LIVR: wrong date in "' + key + '" parameter');
     } else {
         const epoch = Date.parse(param);
 
         if (!epoch && epoch !== 0) {
-            throw new Error('LIVR: wrong date in "' + key + '" parametr');
+            throw new Error('LIVR: wrong date in "' + key + '" parameter');
         }
 
         date = new Date(epoch);

--- a/src/rules/required_if.js
+++ b/src/rules/required_if.js
@@ -18,9 +18,9 @@ function required_if(query) {
     return (value, params) => {
         if (!util.isNoValue(value) || !queryKey) return;
 
-        var valueToCheck = util.JSONPointer(params, queryKey);
+        const valueToCheck = util.JSONPointer(params, queryKey);
 
-        if (valueToCheck == queryValue && util.isNoValue(value)) return 'REQUIRED';
+        if (valueToCheck === queryValue && util.isNoValue(value)) return 'REQUIRED';
 
         return;
     };

--- a/src/rules/uuid.js
+++ b/src/rules/uuid.js
@@ -8,7 +8,7 @@ const uuidRe = {
 };
 
 function uuid(version) {
-    if (arguments.length == 1) {
+    if (arguments.length === 1) {
         version = 'v4';
     }
 
@@ -20,7 +20,7 @@ function uuid(version) {
         if (util.isNoValue(value)) return;
         if (!util.isPrimitiveValue(value)) return 'FORMAT_ERROR';
 
-        if (!(value + '').match(uuidRe[version])) return 'NOT_UUID';
+        if (!(value.toString()).match(uuidRe[version])) return 'NOT_UUID';
         return;
     };
 }

--- a/tests/test_suite.js
+++ b/tests/test_suite.js
@@ -43,9 +43,15 @@ function iterateTestData(path, cb) {
         const caseData = { name: caseDir };
 
         for (const file of caseFiles) {
-            const json = fs.readFileSync(rootPath + '/' + caseDir + '/' + file);
+            const path=rootPath + '/' + caseDir + '/' + file;
+            const json = fs.readFileSync(path);
 
-            caseData[file.replace(/\.json$/, '')] = JSON.parse(json);
+            try {
+                caseData[file.replace(/\.json$/, '')] = JSON.parse(json);
+            }catch(ex) {
+                console.error(`Error reading ${path}`, ex);
+                throw ex;
+            }
         }
 
         cb(caseData);

--- a/tests/test_suite/negative/uuid/errors.json
+++ b/tests/test_suite/negative/uuid/errors.json
@@ -4,7 +4,8 @@
     "uuid_3": "NOT_UUID",
     "uuid_4": "NOT_UUID",
     "uuid_5": "NOT_UUID",
-    
+    "uuid_6": "NOT_UUID",
+
     "value_is_hash":        "FORMAT_ERROR",
     "value_is_empty_hash":  "FORMAT_ERROR",
     "value_is_array":       "FORMAT_ERROR",

--- a/tests/test_suite/negative/uuid/input.json
+++ b/tests/test_suite/negative/uuid/input.json
@@ -4,6 +4,7 @@
     "uuid_3": "b62db7da-f9e9-3476-795e-f3a0f695a6f1",
     "uuid_4": "GGGdb7da-f9e9-4476-a95e-f3a0f695a6f1",
     "uuid_5": "b62db7da-f9e9-5476-a95e-f3a0f695a6f1",
+    "uuid_6": "390f9768-30da-11ec-b8fc-20e2a8b7e430",
     "extra_field": "aaaa",
 
     "value_is_hash":        {"test": 1},

--- a/tests/test_suite/negative/uuid/rules.json
+++ b/tests/test_suite/negative/uuid/rules.json
@@ -4,7 +4,8 @@
     "uuid_3": { "uuid": "v4" },
     "uuid_4": { "uuid": "v5" },
     "uuid_5": "uuid",
-    
+    "uuid_6": "uuid",
+
     "value_is_hash":        "uuid",
     "value_is_empty_hash":  "uuid",
     "value_is_array":       "uuid",

--- a/tests/test_suite/positive/uuid/input.json
+++ b/tests/test_suite/positive/uuid/input.json
@@ -5,6 +5,8 @@
     "uuid_4": "b62db7da-f9e9-4476-a95e-f3a0f695a6f1",
     "uuid_5": "b62db7da-f9e9-5476-a95e-f3a0f695a6f1",
     "uuid_6": "b62dB7da-F9e9-4476-a95E-f3a0f695a6f1",
+    "uuid_7": "390f9768-30da-11ec-b8fc-20e2a8b7e430",
+
     "empty_field": "",
     "extra_field": "aaaa"
 }

--- a/tests/test_suite/positive/uuid/output.json
+++ b/tests/test_suite/positive/uuid/output.json
@@ -5,5 +5,6 @@
     "uuid_4": "b62db7da-f9e9-4476-a95e-f3a0f695a6f1",
     "uuid_5": "b62db7da-f9e9-5476-a95e-f3a0f695a6f1",
     "uuid_6": "b62dB7da-F9e9-4476-a95E-f3a0f695a6f1",
+    "uuid_7": "390f9768-30da-11ec-b8fc-20e2a8b7e430",
     "empty_field": ""
 }

--- a/tests/test_suite/positive/uuid/rules.json
+++ b/tests/test_suite/positive/uuid/rules.json
@@ -5,5 +5,6 @@
     "uuid_4": [ { "uuid": "v4" } ],
     "uuid_5": [ { "uuid": "v5" } ],
     "uuid_6": "uuid",
+    "uuid_7": { "uuid": "v1" },
     "empty_field": "uuid"
 }


### PR DESCRIPTION
The OSX uuid command creates a UUIDv1 by default, and I added an extra UUID test including this output.

I thought about using relaxed JSON for the parsing of the rules, since that would allow comments for
the data items, but felt this was too severe of a delta for now.

I also cleaned up some of the other code bits and corrected spelling.﻿
